### PR TITLE
feat(renderer-puppeteer): add host option for Prerenderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ prerenderer.initialize()
 | Option | Type     | Required? | Default                    | Description                            |
 |--------|----------|-----------|----------------------------|----------------------------------------|
 | port   | Integer  | No        | First free port after 8000 | The port for the app server to run on. |
+| host   | String   | No        | localhost                  | The host for the app server to run on. |
 | proxy  | Object   | No        | No proxying                | Proxy configuration. Has the same signature as [webpack-dev-server](https://webpack.js.org/configuration/dev-server/#devserver-proxy) |
 | before | Function | No        | No operation               | Function for adding custom server middleware. Has the same signature as [webpack-dev-server](https://webpack.js.org/configuration/dev-server/#devserver-before) |
 

--- a/renderers/renderer-puppeteer/es6/renderer.js
+++ b/renderers/renderer-puppeteer/es6/renderer.js
@@ -92,7 +92,7 @@ class PuppeteerRenderer {
               await page.evaluateOnNewDocument(`(function () { window['${options.injectProperty}'] = ${JSON.stringify(options.inject)}; })();`)
             }
 
-            const baseURL = `http://localhost:${rootOptions.server.port}`
+            const baseURL = `http://${rootOptions.server.host || 'localhost'}:${rootOptions.server.port}`
 
             // Allow setting viewport widths and such.
             if (options.viewport) await page.setViewport(options.viewport)


### PR DESCRIPTION
add host option for Prerenderer to use different host in some situation.
 For example: the BE api needs referer validation.