### PR TITLE
Don't try to close Puppeteer if it isn't even open

### DIFF
--- a/renderers/renderer-puppeteer/es6/renderer.js
+++ b/renderers/renderer-puppeteer/es6/renderer.js
@@ -137,7 +137,16 @@ class PuppeteerRenderer {
   }
 
   destroy () {
-    this._puppeteer.close()
+    if(this._puppeteer) {
+      try {
+        this._puppeteer.close()
+      } catch (e) {
+        console.error(e)
+        console.error('[Prerenderer - PuppeteerRenderer] Unable to close Puppeteer')
+		  
+        throw e
+      }
+    }
   }
 }
 


### PR DESCRIPTION
When Puppeteer doesn't even open (missing Chrome dependencies for example) don't try to close it if it doesn't exist. Also, try catch if trying to close it.

When trying to integrate prerendering into a Jenkins job, running Puppeteer would fail since dependencies were missing for Chrome.

However, since closing Puppeteer isn't being handled properly, the node script just hangs forever. Obviously not ideal in a CI/CD environment.

This will now hopefully handle this issue a little more gracefully.