### PR TITLE
Update to puppeteer to 9.1.1

### DIFF
--- a/renderers/renderer-puppeteer/package.json
+++ b/renderers/renderer-puppeteer/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "promise-limit": "^2.5.0",
-    "puppeteer": "^2.0.0"
+    "puppeteer": "^9.1.1"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
The version of Chromium (79.0.3942.0/r706915) attached with Puppeteer 2.0.0 is old enough that it starting to cause issues with our workflow.

After reading through the changelogs, I've confirmed there are no breaking changes between 2.0.0 and the latest version of Puppeteer, run unit tests successfully, and as well done some manual tested to make sure it work successfully. (Some jsdom unit tests failed, but I assume that is unrelated and an existing issue.)